### PR TITLE
feat: add overnight market structure module (6.2)

### DIFF
--- a/src/lib/components/OvernightPanel.svelte
+++ b/src/lib/components/OvernightPanel.svelte
@@ -1,0 +1,252 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import type { OvernightStructure } from '../../../generated/prisma/client';
+
+	const TREND_OPTIONS = ['UP', 'DOWN', 'FLAT', 'MIXED'] as const;
+
+	let {
+		sessionId,
+		overnight
+	}: {
+		sessionId: string;
+		overnight: OvernightStructure | null;
+	} = $props();
+
+	let editing = $state(false);
+
+	const formValues = $state({
+		esTrend: '',
+		nqTrend: '',
+		preMarketVwap: '',
+		overnightHigh: '',
+		overnightLow: '',
+		keyLevels: '',
+		majorNews: '',
+		scheduledReports: ''
+	});
+
+	$effect(() => {
+		if (editing) {
+			formValues.esTrend = overnight?.esTrend ?? '';
+			formValues.nqTrend = overnight?.nqTrend ?? '';
+			formValues.preMarketVwap = overnight?.preMarketVwap?.toString() ?? '';
+			formValues.overnightHigh = overnight?.overnightHigh?.toString() ?? '';
+			formValues.overnightLow = overnight?.overnightLow?.toString() ?? '';
+			formValues.keyLevels = Array.isArray(overnight?.keyLevels)
+				? (overnight!.keyLevels as number[]).join(', ')
+				: '';
+			formValues.majorNews = overnight?.majorNews ?? '';
+			formValues.scheduledReports = overnight?.scheduledReports ?? '';
+		}
+	});
+
+	function parseKeyLevels(s: string): number[] {
+		return s
+			.split(/[\s,]+/)
+			.map((v) => parseFloat(v.trim()))
+			.filter((n) => !isNaN(n));
+	}
+</script>
+
+<div class="card bg-base-200 shadow-md">
+	<div class="card-body p-4">
+		<div class="flex items-center justify-between">
+			<h2 class="card-title text-sm font-semibold uppercase tracking-wider text-base-content/50">
+				Market Structure
+			</h2>
+			{#if overnight}
+				<div class="badge badge-outline badge-sm">
+					{overnight.esTrend} / {overnight.nqTrend}
+				</div>
+			{/if}
+		</div>
+
+		<div class="mt-3">
+			{#if !editing}
+				{#if overnight}
+					<div class="space-y-2 text-sm">
+						<div class="flex gap-4">
+							<span>ES: <span class="font-mono font-medium">{overnight.esTrend}</span></span>
+							<span>NQ: <span class="font-mono font-medium">{overnight.nqTrend}</span></span>
+						</div>
+						<div class="flex gap-4 text-base-content/70">
+							<span>PMH: <span class="font-mono">{overnight.overnightHigh?.toFixed(2) ?? '--'}</span></span>
+							<span>PML: <span class="font-mono">{overnight.overnightLow?.toFixed(2) ?? '--'}</span></span>
+							<span>VWAP: <span class="font-mono">{overnight.preMarketVwap?.toFixed(2) ?? '--'}</span></span>
+						</div>
+						{#if Array.isArray(overnight.keyLevels) && (overnight.keyLevels as number[]).length > 0}
+							<div>
+								<span class="text-base-content/50">Key Levels: </span>
+								<span class="font-mono">{(overnight.keyLevels as number[]).join(', ')}</span>
+							</div>
+						{/if}
+						{#if overnight.majorNews}
+							<div>
+								<span class="text-base-content/50">News: </span>
+								<span>{overnight.majorNews}</span>
+							</div>
+						{/if}
+						{#if overnight.scheduledReports}
+							<div>
+								<span class="text-base-content/50">Reports: </span>
+								<span>{overnight.scheduledReports}</span>
+							</div>
+						{/if}
+					</div>
+				{:else}
+					<p class="text-sm text-base-content/40 italic">No overnight structure entered for this session</p>
+				{/if}
+
+				<button class="btn btn-outline btn-sm mt-3" onclick={() => (editing = true)}>
+					{overnight ? 'Edit Structure' : 'Enter Structure'}
+				</button>
+			{:else}
+				<form
+					method="POST"
+					action="?/saveOvernight"
+					use:enhance={() => {
+						return async ({ update }) => {
+							await update();
+							editing = false;
+						};
+					}}
+				>
+					<input type="hidden" name="sessionId" value={sessionId} />
+
+					<div class="space-y-3">
+						<div class="flex gap-4">
+							<div class="form-control flex-1">
+								<label for="esTrend" class="label py-0">
+									<span class="label-text text-xs">ES Trend</span>
+								</label>
+								<select
+									id="esTrend"
+									name="esTrend"
+									class="select select-xs select-bordered w-full"
+									bind:value={formValues.esTrend}
+									required
+								>
+									<option value="">Select</option>
+									{#each TREND_OPTIONS as opt}
+										<option value={opt}>{opt}</option>
+									{/each}
+								</select>
+							</div>
+							<div class="form-control flex-1">
+								<label for="nqTrend" class="label py-0">
+									<span class="label-text text-xs">NQ Trend</span>
+								</label>
+								<select
+									id="nqTrend"
+									name="nqTrend"
+									class="select select-xs select-bordered w-full"
+									bind:value={formValues.nqTrend}
+									required
+								>
+									<option value="">Select</option>
+									{#each TREND_OPTIONS as opt}
+										<option value={opt}>{opt}</option>
+									{/each}
+								</select>
+							</div>
+						</div>
+
+						<div class="flex gap-2">
+							<div class="form-control flex-1">
+								<label for="preMarketVwap" class="label py-0">
+									<span class="label-text text-xs">Pre-Market VWAP</span>
+								</label>
+								<input
+									id="preMarketVwap"
+									type="number"
+									step="any"
+									name="preMarketVwap"
+									class="input input-xs input-bordered w-full font-mono"
+									placeholder="0.00"
+									bind:value={formValues.preMarketVwap}
+								/>
+							</div>
+							<div class="form-control flex-1">
+								<label for="overnightHigh" class="label py-0">
+									<span class="label-text text-xs">Overnight High</span>
+								</label>
+								<input
+									id="overnightHigh"
+									type="number"
+									step="any"
+									name="overnightHigh"
+									class="input input-xs input-bordered w-full font-mono"
+									placeholder="0.00"
+									bind:value={formValues.overnightHigh}
+								/>
+							</div>
+							<div class="form-control flex-1">
+								<label for="overnightLow" class="label py-0">
+									<span class="label-text text-xs">Overnight Low</span>
+								</label>
+								<input
+									id="overnightLow"
+									type="number"
+									step="any"
+									name="overnightLow"
+									class="input input-xs input-bordered w-full font-mono"
+									placeholder="0.00"
+									bind:value={formValues.overnightLow}
+								/>
+							</div>
+						</div>
+
+						<div class="form-control">
+							<label for="keyLevels" class="label py-0">
+								<span class="label-text text-xs">Key Levels (comma-separated)</span>
+							</label>
+							<input
+								id="keyLevels"
+								type="text"
+								name="keyLevels"
+								class="input input-xs input-bordered w-full font-mono"
+								placeholder="436.0, 438.25, 440.0"
+								bind:value={formValues.keyLevels}
+							/>
+						</div>
+
+						<div class="form-control">
+							<label for="majorNews" class="label py-0">
+								<span class="label-text text-xs">Major News</span>
+							</label>
+							<input
+								id="majorNews"
+								type="text"
+								name="majorNews"
+								class="input input-xs input-bordered w-full"
+								placeholder="Overnight catalysts..."
+								bind:value={formValues.majorNews}
+							/>
+						</div>
+
+						<div class="form-control">
+							<label for="scheduledReports" class="label py-0">
+								<span class="label-text text-xs">Scheduled Reports</span>
+							</label>
+							<input
+								id="scheduledReports"
+								type="text"
+								name="scheduledReports"
+								class="input input-xs input-bordered w-full"
+								placeholder="Economic reports, times..."
+								bind:value={formValues.scheduledReports}
+							/>
+						</div>
+
+						<div class="flex gap-2 mt-3">
+							<button type="submit" class="btn btn-primary btn-sm">Save</button>
+							<button type="button" class="btn btn-ghost btn-sm" onclick={() => (editing = false)}>
+								Cancel
+							</button>
+						</div>
+					</div>
+				</form>
+			{/if}
+		</div>
+	</div>
+</div>

--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -1,9 +1,17 @@
 import { fail } from '@sveltejs/kit';
 import { macroIndicatorService } from '$lib/server/services/macroIndicator.service';
+import { overnightStructureService } from '$lib/server/services/overnightStructure.service';
 import { sessionService } from '$lib/server/services/session.service';
 import { calculateRiskScore, ALL_INDICATORS } from '$lib/macro';
 import type { MacroIndicatorType } from '../../../generated/prisma/client';
 import type { Actions } from './$types';
+
+function parseKeyLevels(s: string): number[] {
+	return s
+		.split(/[\s,]+/)
+		.map((v) => parseFloat(v.trim()))
+		.filter((n) => !isNaN(n));
+}
 
 export const actions: Actions = {
 	saveMacro: async ({ request }) => {
@@ -34,6 +42,50 @@ export const actions: Actions = {
 		await macroIndicatorService.upsertAll(sessionId, dbIndicators);
 
 		await sessionService.updateRiskScore(sessionId, riskResult.score);
+
+		return { success: true };
+	},
+
+	saveOvernight: async ({ request }) => {
+		const formData = await request.formData();
+		const sessionId = formData.get('sessionId') as string;
+
+		if (!sessionId) {
+			return fail(400, { error: 'Missing session ID' });
+		}
+
+		const esTrend = (formData.get('esTrend') as string)?.trim();
+		const nqTrend = (formData.get('nqTrend') as string)?.trim();
+
+		if (!esTrend || !nqTrend) {
+			return fail(400, { error: 'ES and NQ trend are required' });
+		}
+
+		const preMarketVwapRaw = formData.get('preMarketVwap') as string;
+		const overnightHighRaw = formData.get('overnightHigh') as string;
+		const overnightLowRaw = formData.get('overnightLow') as string;
+		const keyLevelsRaw = (formData.get('keyLevels') as string) ?? '';
+		const majorNews = (formData.get('majorNews') as string)?.trim() || undefined;
+		const scheduledReports = (formData.get('scheduledReports') as string)?.trim() || undefined;
+
+		const parseOptFloat = (s: string): number | undefined => {
+			const n = parseFloat(s);
+			return s && !isNaN(n) ? n : undefined;
+		};
+
+		const keyLevels = parseKeyLevels(keyLevelsRaw);
+		const keyLevelsJson = keyLevels.length > 0 ? keyLevels : undefined;
+
+		await overnightStructureService.upsert(sessionId, {
+			esTrend,
+			nqTrend,
+			preMarketVwap: parseOptFloat(preMarketVwapRaw),
+			overnightHigh: parseOptFloat(overnightHighRaw),
+			overnightLow: parseOptFloat(overnightLowRaw),
+			keyLevels: keyLevelsJson,
+			majorNews,
+			scheduledReports
+		});
 
 		return { success: true };
 	}

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import DashboardPanel from '$lib/components/DashboardPanel.svelte';
 	import MacroPanel from '$lib/components/MacroPanel.svelte';
+	import OvernightPanel from '$lib/components/OvernightPanel.svelte';
 
 	let { data } = $props();
 </script>
@@ -8,18 +9,7 @@
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
 	<MacroPanel sessionId={data.session.id} indicators={data.session.macroIndicators} />
 
-	<DashboardPanel title="Market Structure Layer">
-		<div class="space-y-2">
-			<p class="text-sm text-base-content/50">
-				Futures trend, Overnight high/low, VWAP, Opening range
-			</p>
-			<div class="flex gap-4 text-sm">
-				<span>PMH: <span class="text-base-content/40">--</span></span>
-				<span>PML: <span class="text-base-content/40">--</span></span>
-				<span>VWAP: <span class="text-base-content/40">--</span></span>
-			</div>
-		</div>
-	</DashboardPanel>
+	<OvernightPanel sessionId={data.session.id} overnight={data.session.overnightStructure} />
 
 	<DashboardPanel title="Execution Layer">
 		<div class="space-y-2">


### PR DESCRIPTION
- OvernightPanel component with view/edit modes
- ES/NQ trend, PMH/PML, pre-market VWAP, key levels, news, reports
- saveOvernight action wired to overnightStructureService
- Replaces placeholder Market Structure Layer on dashboard

Made-with: Cursor